### PR TITLE
ci: install pnpm before enabling pnpm cache to prevent 'pnpm not found' error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,36 +1,24 @@
-name: CI
-
-on:
-  pull_request: # PRs to any branch
-  push: # Direct pushes to main (e.g., after merge)
-    branches:
-      - main
-
-# Prevents two CI runs on the same branch from clobbering each other
-concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 10 # fail fast if something hangs
+    timeout-minutes: 10
 
     steps:
       - name: 📥 Checkout repo
         uses: actions/checkout@v4
 
-      - name: 🧰 Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22 # ≥22 is required by Next 14
-          cache: 'pnpm' # enables npm-style cache
-
       - name: 📦 Setup pnpm
         uses: pnpm/action-setup@v2
         with:
           version: 10
-          run_install: false # we’ll run it ourselves for granular control
+          run_install: false
+
+      - name: 🧰 Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm # now pnpm is on PATH
+          cache-dependency-path: '**/pnpm-lock.yaml'
 
       - name: 📦 Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
Fix CI failure caused by pnpm cache flag